### PR TITLE
test with the innodb_large_prefix option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,13 @@ script:
     - pv sql/import.sql | mysql app
     - mysql < sql/oldQuery.sql
     - mysql < sql/newQuery.sql
+    - sudo cp mysql-custom-innodb_large_prefix.cnf /etc/mysql/conf.d/mysql-custom.cnf
+    - sudo service mysql restart
+    - mysql < sql/createMetaKeyNotMB4.sql
+    - pv sql/import.sql | mysql app
+    - mysql < sql/oldQuery.sql
+    - mysql < sql/newQuery.sql
+    - mysql < sql/createUTF8mb4innodb_large_prefix.sql
+    - pv sql/import.sql | mysql app
+    - mysql < sql/oldQuery.sql
+    - mysql < sql/newQuery.sql

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,14 @@ script:
     - pv sql/import.sql | mysql app
     - mysql < sql/oldQuery.sql
     - mysql < sql/newQuery.sql
+    - mysql < sql/drop.sql
     - sudo cp mysql-custom-innodb_large_prefix.cnf /etc/mysql/conf.d/mysql-custom.cnf
     - sudo service mysql restart
     - mysql < sql/createMetaKeyNotMB4.sql
     - pv sql/import.sql | mysql app
     - mysql < sql/oldQuery.sql
     - mysql < sql/newQuery.sql
+    - mysql < sql/drop.sql
     - mysql < sql/createUTF8mb4innodb_large_prefix.sql
     - pv sql/import.sql | mysql app
     - mysql < sql/oldQuery.sql

--- a/mysql-custom-innodb_large_prefix.cnf
+++ b/mysql-custom-innodb_large_prefix.cnf
@@ -1,0 +1,3 @@
+[mysqld]
+innodb_data_file_path = ibdata1:10M:autoextend
+innodb_large_prefix=on

--- a/sql/createUTF8mb4innodb_large_prefix.sql
+++ b/sql/createUTF8mb4innodb_large_prefix.sql
@@ -1,0 +1,10 @@
+USE app;
+CREATE TABLE `wp_postmeta` (
+  `meta_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `post_id` bigint(20) unsigned NOT NULL DEFAULT '0',
+  `meta_key` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `meta_value` longtext COLLATE utf8mb4_unicode_ci,
+  PRIMARY KEY (`meta_id`),
+  KEY `post_id` (`post_id`),
+  KEY `meta_key` (`meta_key`)
+) ENGINE=InnoDB AUTO_INCREMENT=212732257 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
the [innodb_large_prefix](http://dev.mysql.com/doc/refman/5.6/en/innodb-parameters.html#sysvar_innodb_large_prefix) option enables  index key prefixes longer than 767 bytes .  Add benchmarking for that to see what difference it makes. 
